### PR TITLE
compatibility with non-template compiling version of vue-cli projects

### DIFF
--- a/src/agGridVue.js
+++ b/src/agGridVue.js
@@ -17,7 +17,7 @@ ComponentUtil.EVENTS.forEach((eventName) => {
 });
 
 export default Vue.extend({
-    template: '<div></div>',
+    render: (h) => h('div'),
     props: props,
     data() {
         return {


### PR DESCRIPTION
ag-grid-vue uses template in Vue.component which is a forbidden word for projects creating using vue-cli and choosing the option : "Runtime-only: about 6KB lighter min+gzip, but templates (or any Vue-specific HTML) are ONLY allowed in  .vue files - render functions are required elsewhere"
so i used a render function in ag-grid-vue